### PR TITLE
Fix: path.joinをなくす

### DIFF
--- a/src/loader/DictionaryLoader.js
+++ b/src/loader/DictionaryLoader.js
@@ -17,7 +17,6 @@
 
 "use strict";
 
-var path = require("path");
 var async = require("async");
 var DynamicDictionaries = require("../dict/DynamicDictionaries");
 
@@ -48,7 +47,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Trie
         function (callback) {
             async.map([ "base.dat.gz", "check.dat.gz" ], function (filename, _callback) {
-                loadArrayBuffer(path.join(dic_path, filename), function (err, buffer) {
+                loadArrayBuffer(`${dic_path}/${filename}`, function (err, buffer) {
                     if(err) {
                         return _callback(err);
                     }
@@ -68,7 +67,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Token info dictionaries
         function (callback) {
             async.map([ "tid.dat.gz", "tid_pos.dat.gz", "tid_map.dat.gz" ], function (filename, _callback) {
-                loadArrayBuffer(path.join(dic_path, filename), function (err, buffer) {
+                loadArrayBuffer(`${dic_path}/${filename}`, function (err, buffer) {
                     if(err) {
                         return _callback(err);
                     }
@@ -88,7 +87,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         },
         // Connection cost matrix
         function (callback) {
-            loadArrayBuffer(path.join(dic_path, "cc.dat.gz"), function (err, buffer) {
+            loadArrayBuffer(`${dic_path}/cc.dat.gz`, function (err, buffer) {
                 if(err) {
                     return callback(err);
                 }
@@ -100,7 +99,7 @@ DictionaryLoader.prototype.load = function (load_callback) {
         // Unknown dictionaries
         function (callback) {
             async.map([ "unk.dat.gz", "unk_pos.dat.gz", "unk_map.dat.gz", "unk_char.dat.gz", "unk_compat.dat.gz", "unk_invoke.dat.gz" ], function (filename, _callback) {
-                loadArrayBuffer(path.join(dic_path, filename), function (err, buffer) {
+                loadArrayBuffer(`${dic_path}/${filename}`, function (err, buffer) {
                     if(err) {
                         return _callback(err);
                     }


### PR DESCRIPTION
## 内容

path.joinをなくして一般的なブラウザ環境でも動くようにします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/2152

## その他
